### PR TITLE
Seagate Lyve fixes

### DIFF
--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -164,6 +164,14 @@ func (p *fwprovider) Schema(ctx context.Context, req provider.SchemaRequest, res
 				Optional:    true,
 				Description: "Resolve an endpoint with FIPS capability",
 			},
+			"account_id": schema.StringAttribute{
+				Optional:    true,
+				Description: "The account ID to use. If not set, the account ID is retrieved via STS API.",
+			},
+			"partition": schema.StringAttribute{
+				Optional:    true,
+				Description: "The partition to use. If not set, the partition is retrieved via STS API.",
+			},
 		},
 		Blocks: map[string]schema.Block{
 			"assume_role": schema.ListNestedBlock{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -249,6 +249,16 @@ func New(ctx context.Context) (*schema.Provider, error) {
 				Optional:    true,
 				Description: "Resolve an endpoint with FIPS capability",
 			},
+			"account_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The account ID to use. If not set, the account ID is retrieved via STS API.",
+			},
+			"partition": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The partition to use. If not set, the partition is retrieved via STS API.",
+			},
 		},
 
 		// Data sources and resources implemented using Terraform Plugin SDK
@@ -496,6 +506,8 @@ func configure(ctx context.Context, provider *schema.Provider, d *schema.Resourc
 		TokenBucketRateLimiterCapacity: d.Get("token_bucket_rate_limiter_capacity").(int),
 		UseDualStackEndpoint:           d.Get("use_dualstack_endpoint").(bool),
 		UseFIPSEndpoint:                d.Get("use_fips_endpoint").(bool),
+		AccountId:                      d.Get("account_id").(string),
+		Partition:                      d.Get("partition").(string),
 	}
 
 	if v, ok := d.Get("retry_mode").(string); ok && v != "" {

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -294,6 +294,7 @@ func findUserByName(ctx context.Context, conn *iam.Client, name string) (*awstyp
 	if output != nil && output.Users != nil {
 		for _, u := range output.Users {
 			if *u.UserName == name {
+				*u.Path = "/" // Seagate Lyve API returns empty path but it must default to "/" when unset
 				return &u, nil
 			}
 		}

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -278,7 +278,8 @@ func findUserByName(ctx context.Context, conn *iam.Client, name string) (*awstyp
 		UserName: aws.String(name),
 	}
 
-	output, err := conn.GetUser(ctx, input)
+	// iam:GetUser is not supported by Seagate Lyve api
+	output, err := conn.ListUsers(ctx, &iam.ListUsersInput{})
 
 	if errs.IsA[*awstypes.NoSuchEntityException](err) {
 		return nil, &retry.NotFoundError{
@@ -290,11 +291,15 @@ func findUserByName(ctx context.Context, conn *iam.Client, name string) (*awstyp
 		return nil, err
 	}
 
-	if output == nil || output.User == nil {
-		return nil, tfresource.NewEmptyResultError(input)
+	if output != nil && output.Users != nil {
+		for _, u := range output.Users {
+			if *u.UserName == name {
+				return &u, nil
+			}
+		}
 	}
 
-	return output.User, nil
+	return nil, tfresource.NewEmptyResultError(input)
 }
 
 func deleteUserGroupMemberships(ctx context.Context, conn *iam.Client, user string) error {


### PR DESCRIPTION
Workarounds to support deployment to Seagate Lyve v2 environment.

There are currently 3 issues:

1. `iam:GetUser` is not supported, returns 403
2. `iam:ListUsers` path is unset but it's expected to default to slash `/`. This results in config diff every time you run terraform. Updating path is also not supported by Seagate API.
3. `sts:GetCallerIdentity` is not supported so allowing to set AccountId and Partition using the `.tf` config file.