### PR TITLE
Seagate Lyve create bucket fixes

### DIFF
--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -6,6 +6,7 @@ package conns
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -186,8 +187,9 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 		return nil, diags
 	}
 
-	accountID := c.AccountId
-	partition := c.Partition
+	// Workaround for Seagate Lyve S3 API not supporting STS GetCallerIdentity
+	accountID := os.Getenv("STS_ACCOUNT_ID")
+	partition := "aws"
 
 	if accountID == "" {
 		tflog.Debug(ctx, "Retrieving AWS account details")

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -164,14 +164,6 @@ func (p *fwprovider) Schema(ctx context.Context, req provider.SchemaRequest, res
 				Optional:    true,
 				Description: "Resolve an endpoint with FIPS capability",
 			},
-			"account_id": schema.StringAttribute{
-				Optional:    true,
-				Description: "The account ID to use. If not set, the account ID is retrieved via STS API.",
-			},
-			"partition": schema.StringAttribute{
-				Optional:    true,
-				Description: "The partition to use. If not set, the partition is retrieved via STS API.",
-			},
 		},
 		Blocks: map[string]schema.Block{
 			"assume_role": schema.ListNestedBlock{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -249,16 +249,6 @@ func New(ctx context.Context) (*schema.Provider, error) {
 				Optional:    true,
 				Description: "Resolve an endpoint with FIPS capability",
 			},
-			"account_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The account ID to use. If not set, the account ID is retrieved via STS API.",
-			},
-			"partition": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The partition to use. If not set, the partition is retrieved via STS API.",
-			},
 		},
 
 		// Data sources and resources implemented using Terraform Plugin SDK
@@ -506,8 +496,6 @@ func configure(ctx context.Context, provider *schema.Provider, d *schema.Resourc
 		TokenBucketRateLimiterCapacity: d.Get("token_bucket_rate_limiter_capacity").(int),
 		UseDualStackEndpoint:           d.Get("use_dualstack_endpoint").(bool),
 		UseFIPSEndpoint:                d.Get("use_fips_endpoint").(bool),
-		AccountId:                      d.Get("account_id").(string),
-		Partition:                      d.Get("partition").(string),
 	}
 
 	if v, ok := d.Get("retry_mode").(string); ok && v != "" {

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -294,7 +294,6 @@ func findUserByName(ctx context.Context, conn *iam.Client, name string) (*awstyp
 	if output != nil && output.Users != nil {
 		for _, u := range output.Users {
 			if *u.UserName == name {
-				*u.Path = "/" // Seagate Lyve API returns empty path but it must default to "/" when unset
 				return &u, nil
 			}
 		}

--- a/internal/service/s3/bucket_accelerate_configuration.go
+++ b/internal/service/s3/bucket_accelerate_configuration.go
@@ -6,10 +6,12 @@ package s3
 import (
 	"context"
 	"log"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -203,6 +205,14 @@ func findBucketAccelerateConfiguration(ctx context.Context, conn *s3.Client, buc
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
+		}
+	}
+
+	// Seagate Lyve does not support GetBucketAccelerateConfiguration but returns 403 instead of 501
+	if tfawserr.ErrCodeEquals(err, errCodeAccessDenied) {
+		return nil, &smithy.GenericAPIError{
+			Code:    errCodeNotImplemented,
+			Message: http.StatusText(http.StatusNotImplemented),
 		}
 	}
 

--- a/internal/service/s3/bucket_acl.go
+++ b/internal/service/s3/bucket_acl.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -278,6 +279,14 @@ func findBucketACL(ctx context.Context, conn *s3.Client, bucket, expectedBucketO
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
+		}
+	}
+
+	// Seagate Lyve does not support GetBucketAcl but returns 403 instead of 501
+	if tfawserr.ErrCodeEquals(err, errCodeAccessDenied) {
+		return nil, &smithy.GenericAPIError{
+			Code:    errCodeNotImplemented,
+			Message: http.StatusText(http.StatusNotImplemented),
 		}
 	}
 

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -464,7 +464,8 @@ func findLifecycleRules(ctx context.Context, conn *s3.Client, bucket, expectedBu
 
 	output, err := conn.GetBucketLifecycleConfiguration(ctx, input)
 
-	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket, errCodeNoSuchLifecycleConfiguration) {
+	// Seagate Lyve returns NoSuchBucketLifecycle instead of NoSuchLifecycleConfiguration
+	if tfawserr.ErrCodeEquals(err, errCodeNoSuchBucket, errCodeNoSuchLifecycleConfiguration, "NoSuchBucketLifecycle") {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,

--- a/internal/service/s3/bucket_replication_configuration.go
+++ b/internal/service/s3/bucket_replication_configuration.go
@@ -6,10 +6,12 @@ package s3
 import (
 	"context"
 	"log"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -457,6 +459,14 @@ func findReplicationConfiguration(ctx context.Context, conn *s3.Client, bucket s
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
+		}
+	}
+
+	// Seagate Lyve does not support GetBucketReplication but returns 403 instead of 501
+	if tfawserr.ErrCodeEquals(err, errCodeAccessDenied) {
+		return nil, &smithy.GenericAPIError{
+			Code:    errCodeNotImplemented,
+			Message: http.StatusText(http.StatusNotImplemented),
 		}
 	}
 

--- a/internal/service/s3/bucket_request_payment_configuration.go
+++ b/internal/service/s3/bucket_request_payment_configuration.go
@@ -6,10 +6,12 @@ package s3
 import (
 	"context"
 	"log"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -204,6 +206,14 @@ func findBucketRequestPayment(ctx context.Context, conn *s3.Client, bucket, expe
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
+		}
+	}
+
+	// Seagate Lyve does not support GetBucketRequestPayment but returns 403 instead of 501
+	if tfawserr.ErrCodeEquals(err, errCodeAccessDenied) {
+		return nil, &smithy.GenericAPIError{
+			Code:    errCodeNotImplemented,
+			Message: http.StatusText(http.StatusNotImplemented),
 		}
 	}
 

--- a/internal/service/s3/bucket_server_side_encryption_configuration.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration.go
@@ -6,10 +6,12 @@ package s3
 import (
 	"context"
 	"log"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -228,6 +230,14 @@ func findServerSideEncryptionConfiguration(ctx context.Context, conn *s3.Client,
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,
+		}
+	}
+
+	// Seagate Lyve does not support GetBucketEncryption but returns 403 instead of 501
+	if tfawserr.ErrCodeEquals(err, errCodeAccessDenied) {
+		return nil, &smithy.GenericAPIError{
+			Code:    errCodeNotImplemented,
+			Message: http.StatusText(http.StatusNotImplemented),
 		}
 	}
 


### PR DESCRIPTION
Remove resolved workarounds:
- [Undo: Seagate Lyve api does not support iam:GetUser](https://github.com/racktopsystems/terraform-provider-aws/commit/f2b0c7d5786a431e9a4f125b8a6db894c319547a)
- [Undo: Seagate Lyve api iam:ListUsers path is unset](https://github.com/racktopsystems/terraform-provider-aws/commit/b559526feaa64864218b4e5b9022dcfd904aa0ad)


Additional workarounds:
- [Seagate Lyve Use env for sts account id](https://github.com/racktopsystems/terraform-provider-aws/commit/960cf82a9bc07e7cead0406f7c9435a2bc081f17)
- [Seagate Lyve does not support HeadBucket](https://github.com/racktopsystems/terraform-provider-aws/commit/662a8adcb11aaabcf6c7c55ec1c636280ddd9bda)
- [Seagate Lyve does not support GetBucketEncryption](https://github.com/racktopsystems/terraform-provider-aws/commit/2c044e5b422c189891c68575b3b4a3ee991d3bff)
- [Seagate Lyve does not support GetBucketReplication](https://github.com/racktopsystems/terraform-provider-aws/commit/7f52acd41a01ecf77244e083eea486dc381e2b98)
- [Seagate Lyve uses invalid 404 code for GetBucketLifecycleConfiguration](https://github.com/racktopsystems/terraform-provider-aws/commit/07af95ea1a8a76a76ab97c25d4388eb18376e8e4)
- [Seagate Lyve does not support GetBucketRequestPayment](https://github.com/racktopsystems/terraform-provider-aws/commit/c553a1e34f958536cf2de8bc67b7f4473a8df40a)
- [Seagate Lyve does not support GetBucketAccelerateConfiguration](https://github.com/racktopsystems/terraform-provider-aws/commit/d83e644748ebe2835e29a22d75e57f2833edbca2)
- [Seagate Lyve does not support GetBucketWebsite](https://github.com/racktopsystems/terraform-provider-aws/commit/1e6028a22285419d81cebdc9acb1fba4642a63a9)
- [Seagate Lyve does not support GetBucketAcl](https://github.com/racktopsystems/terraform-provider-aws/commit/6cb72330ec468f55c356ad0d0eca5f66a114c424)